### PR TITLE
Update xml_import_export.php

### DIFF
--- a/controller/xml_import_export.php
+++ b/controller/xml_import_export.php
@@ -130,7 +130,7 @@ class xml_import_export extends fs_controller {
                   /// pero sólo queremos las columnas comunes con la tabla de la base de datos
                   foreach ($this->db->get_columns($tabla) as $col1) {
                      foreach ($xml->columnas->columna as $col2) {
-                        if ($col1['column_name'] == $col2) {
+                        if ($col1['name'] == $col2) {
                            $columnas[] = $col2;
                            break;
                         }


### PR DESCRIPTION
Corrección a los errores: 
Error al ejecutar la consulta 0: Field 'descripcion' doesn't have a default value. La secuencia ocupa la posición 7
Error al ejecutar la consulta 0: Field 'descripcion' doesn't have a default value. La secuencia ocupa la posición 28
Error al ejecutar la consulta 0: Field 'descripcion' doesn't have a default value. La secuencia ocupa la posición 10